### PR TITLE
Reorganize Workflow action: publish to Maven Central and make release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     - uses: whoan/docker-build-with-cache-action@v5
       with:
-        username: victor-paltz
+        username: ${{ github.actor }}
         password: "${{ secrets.GITHUB_TOKEN }}"
         registry: docker.pkg.github.com
         #or
@@ -29,13 +29,13 @@ jobs:
 
     # - run: docker image ls
 
-    - run: docker run -v "/home/runner/work/JFaiss-CPU/JFaiss-CPU":"/github/workspace" docker.pkg.github.com/victor-paltz/jfaiss-cpu/jfaiss-cpu
+    - run: docker run -v "/home/runner/work/jfaiss-cpu/jfaiss-cpu":"/github/workspace" docker.pkg.github.com/criteo/jfaiss-cpu/jfaiss-cpu
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: faiss_JNI_and_SO
         path: build
-    
+
 
   build:
     needs: build_faiss
@@ -46,7 +46,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: faiss_JNI_and_SO
           path: build_copy
@@ -60,17 +60,7 @@ jobs:
       # - name: Debugging with tmate
       #   uses: mxschmitt/action-tmate@v3
 
-      # - name: Publish package
-      #   run: mvn -B deploy
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Release Maven package
-        uses: samuelmeuli/action-maven-publish@v1
-        with:
-          gpg_private_key: ${{ secrets.gpg_private_key }}
-          gpg_passphrase: ${{ secrets.gpg_passphrase }}
-          nexus_username: ${{ secrets.nexus_username }}
-          nexus_password: ${{ secrets.nexus_password }}
+      - name: Publish package
+        run: mvn -B deploy
         env:
-          GPG_TTY: $(tty)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum install -y lapack lapack-devel
 
 # Install necessary build tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV LD_PRELOAD=${LD_PRELOAD}:/opt/intel/mkl/lib/intel64/libmkl_gnu_thread.so
 COPY . /opt/JFaiss
 WORKDIR /opt/JFaiss/faiss
 
-ENV CXXFLAGS="-mavx2 -mf16c"
+ENV CXXFLAGS=${CXXFLAGS}" -mavx2 -mf16c -I/opt/JFaiss"
 # Install faiss
 RUN ./configure --prefix=/usr --without-cuda
 RUN make -j $(nproc)

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.victor-paltz</groupId>
-    <artifactId>JFaiss-CPU</artifactId>
+    <groupId>com.criteo.jfaiss</groupId>
+    <artifactId>jfaiss-cpu</artifactId>
     <version>2.1.0</version>
 
     <properties>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -32,17 +32,22 @@
     <description>
         Faiss v1.6.3 bindings for Java
     </description>
-    <url>https://github.com/victor-paltz/JFaiss-CPU.git</url>
+    <url>https://github.com/criteo/jfaiss-cpu.git</url>
 
     <licenses>
         <license>
             <name>MIT License</name>
             <url>http://www.opensource.org/licenses/mit-license.php</url>
-            <distribution>repo</distribution>
         </license>
     </licenses>
 
     <developers>
+        <developer>
+            <name>Criteo</name>
+            <email>github@criteo.com</email>
+            <organization>Criteo</organization>
+            <organizationUrl>https://github.com/criteo</organizationUrl>
+        </developer>
         <developer>
             <name>Raman Rajarathinam</name>
             <email>ramanrajarathinam@gmail.com</email>
@@ -72,22 +77,11 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/victor-paltz/JFaiss-CPU.git</connection>
-        <developerConnection>scm:git:ssh://github.com/victor-paltz/JFaiss-CPU.git</developerConnection>
-        <url>https://github.com/victor-paltz/JFaiss-CPU.git</url>
+        <connection>scm:git:https://github.com/criteo/jfaiss-cpu.git</connection>
+        <developerConnection>scm:git:ssh://github.com/criteo/jfaiss-cpu.git</developerConnection>
+        <url>https://github.com/criteo/jfaiss-cpu.git</url>
         <tag>HEAD</tag>
     </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <build>
         <plugins>
@@ -150,56 +144,15 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-api</artifactId>
-                        <version>1.10.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.10.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/criteo/jfaiss-cpu</url>
+        </repository>
+    </distributionManagement>
 
     <profiles>
         <profile>
@@ -233,29 +186,6 @@
                         <goal>jar</goal>
                         </goals>
                     </execution>
-                    </executions>
-                </plugin>
-
-                <!-- GPG plugin -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                    <executions>
-                        <execution>
-                            <id>sign-artifacts</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sign</goal>
-                            </goals>
-                            <configuration>
-                                <!-- Prevent `gpg` from using pinentry programs -->
-                                <gpgArguments>
-                                    <arg>--pinentry-mode</arg>
-                                    <arg>loopback</arg>
-                                </gpgArguments>
-                            </configuration>
-                        </execution>
                     </executions>
                 </plugin>
                 </plugins>


### PR DESCRIPTION
 - Fix GPG-signing when publishing.
 - Publish resulting jar-library to the Maven Central instead of GitHub.
 - Create release from GitHub workflow on pull-requests and pushes to master.
 - Set version to match the version of FAISS.
 - Use commit hash as version suffix
